### PR TITLE
refactor spawning

### DIFF
--- a/creep.actions.js
+++ b/creep.actions.js
@@ -18,7 +18,7 @@ module.exports = {
     _say(creep, '🏗 build')
     _headToBuildTargetAndBuild(creep)
   },
-  murder: function(creep, target) {
+  murder: function(creep) {
     _say(creep, 'MURDER')
     _headToEnemyAndAttack(creep)
   },
@@ -90,7 +90,6 @@ var _headToEnergySourceAndHarvest = function(creep) {
       if(source) {
         creep.memory['source'] = source.id
         harvestResults = creep.harvest(source)
-        if(harvestResults == OK) _say(creep,'💲')
         if(harvestResults == ERR_NOT_IN_RANGE) creep.moveTo(source, {visualizePathStyle: {stroke: '#ffaa00'}})
       } else {
         _headToHangout(creep)

--- a/creep.helper.js
+++ b/creep.helper.js
@@ -1,0 +1,113 @@
+module.exports = {
+  getCreeps: function() {
+    var creeps = []
+    for(var creep in Game.creeps) {
+      creeps.push(Game.creeps[creep])
+    }
+    if(creeps.length > 0) {
+      return creeps
+    } else {
+      return null
+    }
+  },
+
+  getCreepCount: function(creepRole) {
+    var creepCount = 0
+    for(var creep in Game.creeps) {
+      if(Game.creeps[creep].memory.role == creepRole) {
+        creepCount++
+      }
+    }
+    return creepCount
+  },
+
+  getRoles: function() {
+    return {
+      'harvester': {
+        'name': 'harvester',
+        'minCount': 3,
+        'maxCount': 6,
+        'priority': 0,
+        'template': _baseCreeps
+      },
+      'upgrader': {
+        'name': 'upgrader',
+        'minCount': 2,
+        'maxCount': 3,
+        'priority': 1,
+        'template': _baseCreeps
+      },
+      'builder': {
+        'name': 'builder',
+        'minCount': 2,
+        'maxCount': 4,
+        'priority': 2,
+        'template': _baseCreeps
+      },
+      'defender': {
+        'name': 'defender',
+        'minCount': 1,
+        'maxCount': 2,
+        'priority': 3,
+        'template': _defenderCreeps
+      }
+    }
+  }
+}
+
+var _addToughness = function(parts, amount) {
+  for(var i = 0; i < amount; i++) {
+    parts.unshift(TOUGH)
+  }
+  return parts
+}
+
+var _baseCreeps = {
+  levelZero: {
+    level: 0,
+    bodyParts: [WORK, MOVE, CARRY],
+    price: 200
+  },
+  levelOne: {
+    level: 1,
+    bodyParts: [WORK, MOVE, MOVE, CARRY, CARRY],
+    price: 300
+  },
+  levelTwo: {
+    level: 2,
+    bodyParts: [WORK, MOVE, MOVE, CARRY, CARRY, CARRY],
+    price: 350
+  },
+  levelThree: {
+    level: 3,
+    bodyParts: [WORK, WORK, MOVE, MOVE, MOVE, CARRY, CARRY, CARRY],
+    price: 500
+  }
+}
+
+var _defenderCreeps = {
+  levelZero: {
+    level: 0,
+    toughness: 10,
+    bodyParts: _addToughness([MOVE, MOVE, CARRY, ATTACK], 10),
+    price: 330
+  },
+  levelOne: {
+    level: 1,
+    toughness: 20,
+    bodyParts: _addToughness([MOVE, MOVE, CARRY, RANGED_ATTACK], 20),
+    price: 500
+  },
+  levelTwo: {
+    level: 2,
+    toughness: 30,
+    bodyParts: _addToughness([MOVE, MOVE, CARRY, ATTACK, ATTACK], 30),
+    price: 610
+  },
+  levelThree: {
+    level: 3,
+    toughness: 35,
+    bodyParts: _addToughness([MOVE, MOVE, CARRY, RANGED_ATTACK, RANGED_ATTACK], 35),
+    price: 800
+  }
+}

--- a/creep.runner.js
+++ b/creep.runner.js
@@ -1,3 +1,5 @@
+var creepHelper = require('creep.helper')
+
 var roleHarvester = require('role.harvester')
 var roleUpgrader = require('role.upgrader')
 var roleBuilder = require('role.builder')
@@ -7,7 +9,7 @@ var roles = ['harvester', 'upgrader', 'builder']
 var roomName = 'W5N8'
 module.exports = {
   run: function() {
-    var creeps = _getCreeps()
+    var creeps = creepHelper.getCreeps()
     for(var i = 0; i < creeps.length; i++) {
       if(creeps[i].memory.role == 'harvester') {
         if(_spawnHasCapacity()) {
@@ -21,20 +23,12 @@ module.exports = {
         if(_buildTargetExists()) {
           roleBuilder.run(creeps[i])
         } else {
-          roleUpgrader.run(creeps[i])
+          roleHarvester.run(creeps[i])
         }
       }
       if(creeps[i].memory.role == 'defender') roleDefender.run(creeps[i])
     }
   }
-}
-
-var _getCreeps = function() {
-  var creeps = []
-  for(var creep in Game.creeps) {
-    creeps.push(Game.creeps[creep])
-  }
-  return creeps
 }
 
 var _buildTargetExists = function() {

--- a/room.helper.js
+++ b/room.helper.js
@@ -1,0 +1,10 @@
+module.exports = {
+  getRoomNames: function() {
+    var rooms = []
+    for(var room in Game.rooms) {
+      rooms.push(room.name)
+    }
+    if(rooms.length == 1) return rooms[0]
+    return rooms
+  }
+}

--- a/spawn.creator.js
+++ b/spawn.creator.js
@@ -1,207 +1,61 @@
+var creepHelper = require('creep.helper')
+var roomHelper = require('room.helper')
 var structures = require('structure.helper')
+
 var roomName = 'W5N8'
 var maxCreepCount = 5
 var maxDefenderCount = 2
 module.exports = {
   breed: function() {
-    _spawnCreep(function() {
-      _spawnDefender()
-    })
-  }
-// }
-  // specialOrder: function() {
-  //   var buildingWithSpecialOrders = structures.findSpecialOrders('spawn', 'breed')
-  //   if(buildingWithSpecialOrders) {
-  //     var specialOrders = buildingWithSpecialOrders.memory.specialOrder
-  //     var spawnToUse = structures.findAvailableSpawn()
-  //     if(spawnToUse && _specialOrderIsValid(specialOrders)) {
-  //       var bodyParts = specialOrders.templateName ? _baseCreeps[specialOrders.templateName].bodyParts : specialOrders.bodyParts
-  //       if(_energyIsAvailableToBreed(bodyParts)) {
-  //         if(typeof(spawnToUse.createCreep(bodyParts, {role: specialOrders.role, level: specialOrders.level})) == 'string') {
-  //           console.log('Special breed order executed, deleting order')
-  //           delete(buildingWithSpecialOrders.memory.specialOrders)
-  //         } else {
-  //           console.log('Failed to execute special breed order.  Spawn command didn\'t work')
-  //         }
-  //       } else {
-  //         console.log('Failed to execute special breed order.  Not enough energy')
-  //       }
-  //     } else {
-  //       console.log('Failed to execute special breed order.  No available spawn, or bad object')
-  //     }
-  //   }
-  // }
-}
-/** ToDO:  Change this to allow for max creep per role, remove recursion
-  *        and handle specifics for defender roles, possibly invader roles
-  *        move defender code into _spawnCreep method.
-**/
-var _spawnCreep = function(callback, count) {
-  var spawn = structures.findAvailableSpawn()
-  if(spawn) {
-    count = count ? count : 0
-    var energy = _getAvailableSpawnEnergy()
-    var roles = ['harvester', 'upgrader', 'builder']
-    if(_getCreepCount(roles[count]) < maxCreepCount) {
-      var creepTemplate = _getHighestLevelTemplate(energy)
-      if(creepTemplate) {
-        spawn.createCreep(creepTemplate.bodyParts, {role: roles[count], level: creepTemplate.level})
-        return callback()
-      } else {
-        return callback()
-      }
-    }
-    count++
-    if(count < (roles.length)) {
-      return _spawnCreep(callback, count)
-    } else {
-      return callback()
-    }
-  } else {
-    return callback()
+    _spawnCreep()
   }
 }
 
-var _spawnDefender = function(spawn) {
+var _spawnCreep = function() {
   var spawn = structures.findAvailableSpawn()
   if(spawn) {
     var energy = _getAvailableSpawnEnergy()
-    if(_getDefenderCount() < maxDefenderCount) {
-      var creepTemplate = _getHighestLevelDefender(energy)
-      if(creepTemplate) {
-        _addToughnessToCreep(creepTemplate)
-        return spawn.createCreep(creepTemplate.bodyParts, {role: 'defender', level: creepTemplate.level})
-      } else {
-        return
+    var role = _getMostNeededRole()
+    if(role) {
+      var template = _getHighestLevelTemplate(energy, role)
+      if(template) {
+        spawn.createCreep(template.bodyParts, {role: role.name, level: template.level})
       }
     }
+  }
+}
+
+var _getMostNeededRole = function() {
+  var creeps = creepHelper.getCreeps()
+  var roles = creepHelper.getRoles()
+  if(creeps) {
+    for(var role in roles) {
+      if(roles[role].minCount > creepHelper.getCreepCount(role)) return roles[role]
+    }
+
+    for(var role in roles) {
+      if(roles[role].maxCount > creepHelper.getCreepCount(role)) return roles[role]
+    }
+
   } else {
-    return
-  }
-}
-
-var _getDefenderCount = function() {
-  return _getCreepCount('defender')
-}
-
-var _getHighestLevelDefender = function(energy) {
-  var highestAffordableTemplate = {price:0}
-  var tempTemplate
-  for(var template in _defenderCreeps) {
-    tempTemplate = _defenderCreeps[template]
-    if(tempTemplate.price <= energy && tempTemplate.price > highestAffordableTemplate.price) {
-      highestAffordableTemplate = tempTemplate
+    for(var role in roles) {
+      if(roles[role].priority == 0) return roles[role]
     }
   }
-  return highestAffordableTemplate
-}
-
-var _specialOrderIsValid = function(specialOrder) {
-  if((specialOrder.template || specialOrder.bodyParts) && (specialOrder.role && specialOrder.level)) {
-    return true
-  }
-  console.log('Bad order object should be: {template: templateName || bodyParts: [PARTS], role: roleName, level: #}')
-  return false
-}
-
-var _getCreepCount = function(creepRole) {
-  var creepCount = 0
-  for(var creep in Game.creeps) {
-    if(Game.creeps[creep].memory.role == creepRole) {
-      creepCount++
-    }
-  }
-  return creepCount
 }
 
 var _getAvailableSpawnEnergy = function() {
   return Game.rooms[roomName].energyAvailable
 }
 
-var _getHighestLevelTemplate = function(energy) {
+var _getHighestLevelTemplate = function(energy, role) {
   var highestAffordableTemplate = {price:0}
   var tempTemplate
-  for(var template in _baseCreeps) {
-    tempTemplate = _baseCreeps[template]
+  for(var template in role.template) {
+    tempTemplate = role.template[template]
     if(tempTemplate.price <= energy && tempTemplate.price > highestAffordableTemplate.price) {
       highestAffordableTemplate = tempTemplate
     }
   }
   return highestAffordableTemplate
-}
-
-var _addToughnessToCreep = function(creepTemplate) {
-  for(var i = 0; i < creepTemplate.toughness; i++) {
-    creepTemplate.bodyParts.unshift(TOUGH)
-  }
-}
-
-var _energyIsAvailableToBreed = function(bodyParts) {
-  var prices = {
-    tough: 10,
-    move: 50,
-    carry: 50,
-    attack: 80,
-    work: 100,
-    ranged_attack: 150,
-    heal: 250,
-    claim: 600
-  }
-  var availableEnergy = _getAvailableSpawnEnergy()
-  var totalCost = -1
-
-  for(var i = 0; i < bodyParts.length; i++) {
-    totalCost = totalCost + prices[bodyParts[i]]
-  }
-  return totalCost > -1 && totalCost <= availableEnergy
-}
-
-var _baseCreeps = {
-  levelZero: {
-    level: 0,
-    bodyParts: [WORK, MOVE, CARRY],
-    price: 200
-  },
-  levelOne: {
-    level: 1,
-    bodyParts: [WORK, MOVE, MOVE, CARRY, CARRY],
-    price: 300
-  },
-  levelTwo: {
-    level: 2,
-    bodyParts: [WORK, MOVE, MOVE, CARRY, CARRY, CARRY],
-    price: 350
-  },
-  levelThree: {
-    level: 3,
-    bodyParts: [WORK, WORK, MOVE, MOVE, MOVE, CARRY, CARRY, CARRY],
-    price: 500
-  }
-}
-
-var _defenderCreeps = {
-  levelZero: {
-    level: 0,
-    toughness: 10,
-    bodyParts: [MOVE, MOVE, CARRY, ATTACK],
-    price: 330
-  },
-  levelOne: {
-    level: 1,
-    toughness: 20,
-    bodyParts: [MOVE, MOVE, CARRY, RANGED_ATTACK],
-    price: 500
-  },
-  levelTwo: {
-    level: 2,
-    toughness: 30,
-    bodyParts: [MOVE, MOVE, CARRY, ATTACK, ATTACK],
-    price: 610
-  },
-  levelThree: {
-    level: 3,
-    toughness: 35,
-    bodyParts: [MOVE, MOVE, CARRY, RANGED_ATTACK, RANGED_ATTACK],
-    price: 800
-  }
 }

--- a/specialOrders.js
+++ b/specialOrders.js
@@ -4,3 +4,34 @@
 
 Game.spawns['Spawn1'].memory['specialOrder'] = {type: 'breed', templateName: levelThree, role: 'harvester', level: 3}
 Game.spawns['Spawn1'].memory['specialOrder'] = {type: 'breed', bodyParts: [WORK, MOVE, CARRY, CARRY, CARRY], role: 'harvester', level: 4}
+
+// specialOrder: function() {
+//   var buildingWithSpecialOrders = structures.findSpecialOrders('spawn', 'breed')
+//   if(buildingWithSpecialOrders) {
+//     var specialOrders = buildingWithSpecialOrders.memory.specialOrder
+//     var spawnToUse = structures.findAvailableSpawn()
+//     if(spawnToUse && _specialOrderIsValid(specialOrders)) {
+//       var bodyParts = specialOrders.templateName ? _baseCreeps[specialOrders.templateName].bodyParts : specialOrders.bodyParts
+//       if(_energyIsAvailableToBreed(bodyParts)) {
+//         if(typeof(spawnToUse.createCreep(bodyParts, {role: specialOrders.role, level: specialOrders.level})) == 'string') {
+//           console.log('Special breed order executed, deleting order')
+//           delete(buildingWithSpecialOrders.memory.specialOrders)
+//         } else {
+//           console.log('Failed to execute special breed order.  Spawn command didn\'t work')
+//         }
+//       } else {
+//         console.log('Failed to execute special breed order.  Not enough energy')
+//       }
+//     } else {
+//       console.log('Failed to execute special breed order.  No available spawn, or bad object')
+//     }
+//   }
+// }
+
+var _specialOrderIsValid = function(specialOrder) {
+  if((specialOrder.template || specialOrder.bodyParts) && (specialOrder.role && specialOrder.level)) {
+    return true
+  }
+  console.log('Bad order object should be: {template: templateName || bodyParts: [PARTS], role: roleName, level: #}')
+  return false
+}


### PR DESCRIPTION
creates creep.helper and room.helper, for shared utility methods.  creep.helper holds the templates, and build info for each creep type.  Defenders are now handled the same way as the rest of the creeps and spawned last.