### PR TITLE
towers always attack when enemy exists

### DIFF
--- a/creep.helper.js
+++ b/creep.helper.js
@@ -25,6 +25,11 @@ module.exports = {
     return creepCount
   },
 
+  findClosestDamagedCreep: function(requestor) {
+    var filter = {filter: function(creep) { return creep.hits < creep.hitsMax }}
+    return requestor.pos.findClosestByRange(FIND_MY_CREEPS, filter)
+  },
+
   getRoles: function() {
     return {
       'harvester': {
@@ -50,8 +55,8 @@ module.exports = {
       },
       'defender': {
         'name': 'defender',
-        'minCount': 1,
-        'maxCount': 2,
+        'minCount': 0,
+        'maxCount': 0,
         'priority': 3,
         'template': _defenderCreeps
       }
@@ -93,25 +98,25 @@ var _defenderCreeps = {
   levelZero: {
     level: 0,
     toughness: 10,
-    bodyParts: _addToughness([MOVE, MOVE, CARRY, ATTACK], 10),
+    bodyParts: _addToughness([MOVE, CARRY, ATTACK, MOVE], 10),
     price: 330
   },
   levelOne: {
     level: 1,
     toughness: 20,
-    bodyParts: _addToughness([MOVE, MOVE, CARRY, RANGED_ATTACK], 20),
+    bodyParts: _addToughness([MOVE, CARRY, RANGED_ATTACK, MOVE], 20),
     price: 500
   },
   levelTwo: {
     level: 2,
     toughness: 30,
-    bodyParts: _addToughness([MOVE, MOVE, CARRY, ATTACK, ATTACK], 30),
+    bodyParts: _addToughness([MOVE, CARRY, ATTACK, ATTACK, MOVE], 30),
     price: 610
   },
   levelThree: {
     level: 3,
     toughness: 35,
-    bodyParts: _addToughness([MOVE, MOVE, CARRY, RANGED_ATTACK, RANGED_ATTACK], 35),
+    bodyParts: _addToughness([MOVE, CARRY, RANGED_ATTACK, RANGED_ATTACK, MOVE], 35),
     price: 800
   }
 }

--- a/main.js
+++ b/main.js
@@ -28,9 +28,11 @@ var checkForEnemies = function() {
 var hackFixRoleLessCreeps = function() {
   for(var creep in Game.creeps) {
     if(!Game.creeps[creep].memory) {
+      console.log(`${creep.name} has no memory.`)
       Game.creeps[creep].memory = {'role': 'harvester'}
     }
     if(!Game.creeps[creep].memory.role) {
+      console.log(`${creep.name} has no role.`)
       Game.creeps[creep].memory['role'] = 'harvester'
     }
   }

--- a/spawn.creator.js
+++ b/spawn.creator.js
@@ -17,8 +17,8 @@ var _spawnCreep = function() {
     if(role) {
       var template = _getHighestLevelTemplate(energy, role)
       if(template) {
-        console.log(`Spawning: ${role.name}`)
-        spawn.createCreep(template.bodyParts, {role: role.name, level: template.level})
+        var creepName = spawn.createCreep(template.bodyParts, {role: role.name, level: template.level})
+        console.log(`Spawned: ${creepName} - ${role.name}`)
       }
     }
   }

--- a/tower.runner.js
+++ b/tower.runner.js
@@ -1,29 +1,23 @@
-var structs = require('structure.helper')
+var sHelper = require('structure.helper')
+var cHelper = require('creep.helper')
 
 module.exports = {
   run: function() {
-    var towers = structs.findTowers()
+    var towers = sHelper.findTowers()
     for(var i = 0; i < towers.length; i++) {
-      _findAndAttackHostile(towers[i])
-      _findAndRepairStructure(towers[i])
-      _findAndHealCreep(towers[i])
+      _runTower(towers[i])
     }
   }
 }
 
-var _findAndAttackHostile = function(tower) {
-  var closestHostile = tower.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
-  if(closestHostile) tower.attack(closestHostile)
-}
+var _runTower = function(tower) {
+  var closestHostile, closestDamagedStructure, closestDamagedCreep
+  closestHostile = tower.pos.findClosestByRange(FIND_HOSTILE_CREEPS)
+  if(closestHostile) return tower.attack(closestHostile)
 
-var _findAndRepairStructure = function(tower) {
-  var filter = {filter: function(structure) { return structure.hits < structure.hitsMax }}
-  var closestDamagedStructure = tower.pos.findClosestByRange(FIND_STRUCTURES, filter)
-  if(closestDamagedStructure) tower.repair(closestDamagedStructure)
-}
+  closestDamagedStructure = sHelper.findClosestDamagedStructure(tower)
+  if(closestDamagedStructure) return tower.repair(closestDamagedStructure)
 
-var _findAndHealCreep = function(tower) {
-  var filter = {filter: function(creep) { return creep.hits < creep.hitsMax }}
-  var closestDamagedCreep = tower.pos.findClosestByRange(FIND_MY_CREEPS, filter)
-  if(closestDamagedCreep) tower.heal(closestDamagedCreep)
+  closestDamagedCreep = cHelper.findClosestDamagedCreep(tower)
+  if(closestDamagedCreep) return tower.heal(closestDamagedCreep)
 }


### PR DESCRIPTION
if bad guy exists, tower will attack until dead or tower is out of energy.  Changes deposit logic to set single creep to handle reload of tower, instead of all creeps going to the same tower.  Also changed to only reload towers when they have lost at least 50 power first.  Disabled defenders until they can be useful